### PR TITLE
allow language selection in tui command

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,7 @@ enum Commands {
     /// Authenticate with LeetCode
     Auth,
     /// Launch the TUI (Placeholder for now)
-    Tui,
+    Tui { language: Option<Language> },
     /// Check auth status
     Status,
     /// Pick a problem
@@ -113,7 +113,7 @@ async fn main() -> anyhow::Result<()> {
                 }
             }
         }
-        Some(Commands::Tui) => open_tui().await,
+        Some(Commands::Tui {language}) => open_tui(language).await,
         Some(Commands::Status) => {
             match LeetCodeCredentials::load() {
                 Some(creds) => {
@@ -205,7 +205,7 @@ async fn main() -> anyhow::Result<()> {
                 _ => todo!(),
             }
         }
-        None => open_tui().await,
+        None => open_tui(&None).await,
     };
 
     Ok(())
@@ -256,7 +256,7 @@ pub async fn pick_and_open(
 }
 
 /// Fetches the full problem list and user data, then launches the interactive TUI.
-async fn open_tui() {
+async fn open_tui(language: &Option<Language>) {
     let creds = leetrs::auth::LeetCodeCredentials::load().expect("Please run `leetrs auth` first.");
     let client = leetrs::client::LeetCodeClient::new(creds).expect("Failed to init client");
 
@@ -274,5 +274,5 @@ async fn open_tui() {
 
     let user_data = picker.get_user_data().await.ok();
 
-    let _ = leetrs::tui::run_tui(Rc::clone(&problems), picker, user_data).await;
+    let _ = leetrs::tui::run_tui(Rc::clone(&problems), picker, user_data, language).await;
 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -98,6 +98,7 @@ pub async fn run_tui(
     problems: Rc<[ProblemSummary]>,
     picker: Picker,
     user_detail: Option<UserDetail>,
+    language: &Option<Language>,
 ) -> anyhow::Result<()> {
     let mut app = App::new(problems, user_detail);
     let _result = loop {
@@ -115,7 +116,7 @@ pub async fn run_tui(
 
         match result {
             Ok(Some(problem)) => {
-                pick_and_open_nvim(&picker, &Identifier::String(problem), &None).await;
+                pick_and_open_nvim(&picker, &Identifier::String(problem), language).await;
                 app.selection_screen.input_mode = InputMode::Normal;
                 app.should_quit = false;
                 app.selected_problem = None;


### PR DESCRIPTION
## What does this PR do?

Adds a 'language' argument to the 'tui' command similar to the 'pick' command.
Now users who use the UI to select problems can open the problem with the programming language of their choosing.


## Type of change

<!-- Check all that apply. -->
- [ ] 🐛 Bug fix
- [x] 🚀 New feature
- [ ] ♻️ Refactor / code cleanup
- [ ] 📄 Documentation update
- [ ] 🔧 Build / CI change
- [ ] ⚡ Performance improvement

## Checklist


- [x] The code compiles without warnings (`cargo build`)
- [ ] Added / Modified testcases related to this PR
- [x] All tests passed successfully.
- [x] `cargo clippy` passes with no new lints
- [x] Existing behaviour is unchanged (or breaking changes are documented below)
- [x] Relevant documentation / comments have been updated
  - cli help message added automatically
