### PR TITLE
Discussion: add Firefox XDG profile fallback

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -93,7 +93,23 @@ pub fn auto_extract_flow(browser: &str) -> Result<LeetCodeCredentials, String> {
             rookie::chrome(domains).map_err(|e| format!("Chrome extraction failed: {}", e))?
         }
         "firefox" => {
-            rookie::firefox(domains).map_err(|e| format!("Firefox extraction failed: {}", e))?
+            match rookie::firefox(domains.clone()) {
+                Ok(cookies) => cookies,
+                Err(rookie_err) => {
+                    // Fallback for Firefox profiles stored under the XDG config directory
+                    let cookie_db = find_first_firefox_xdg_cookie_db_path().ok_or_else(|| {
+                        format!(
+                            "Firefox cookie extraction failed: rookie autodiscovery failed ({rookie_err}); no XDG Firefox cookie DB found"
+                        )
+                    })?;
+
+                    rookie::any_browser(&cookie_db, domains.clone(), None).map_err(|fallback_err| {
+                        format!(
+                            "Firefox cookie extraction failed: rookie autodiscovery failed ({rookie_err}); XDG fallback '{cookie_db}' failed ({fallback_err})"
+                        )
+                    })?
+                }
+            }
         }
         _ => return Err("Unsupported browser".into()),
     };
@@ -119,6 +135,31 @@ pub fn auto_extract_flow(browser: &str) -> Result<LeetCodeCredentials, String> {
             "Could not find both LEETCODE_SESSION and csrftoken in the browser's database.".into(),
         ),
     }
+}
+
+// Finds the first Firefox cookies.sqlite database under the XDG config profile directory.
+fn find_first_firefox_xdg_cookie_db_path() -> Option<String> {
+    let firefox_root = firefox_xdg_config_dir()?;
+
+    fs::read_dir(firefox_root)
+        .ok()?
+        .flatten()
+        .map(|entry| entry.path().join("cookies.sqlite"))
+        .find(|cookie_db| cookie_db.exists())
+        .and_then(|path| path.into_os_string().into_string().ok())
+}
+
+// Resolves the Firefox XDG config directory, respecting XDG_CONFIG_HOME and falling back to ~/.config.
+fn firefox_xdg_config_dir() -> Option<PathBuf> {
+    let config_home = std::env::var_os("XDG_CONFIG_HOMEE")
+        .map(PathBuf::from)
+        .or_else(|| {
+            std::env::var_os("HOME")
+                .map(PathBuf::from)
+                .map(|home| home.join(".config"))
+        })?;
+
+    Some(config_home.join("mozilla/firefox"))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
On some Linux setups, `leetrs auth` fails to extract Firefox cookies because Firefox stores profiles under `~/.config/mozilla/firefox/<profile>/cookies.sqlite`, but Rookie’s Firefox autodiscovery does not search that location.

`leetrs auth` currently relies on Rookie for Firefox cookie discovery. Rookie does not appear to cover this profile layout, and the project seems inactive, so this PR explores handling the missing path locally.

The fallback only runs when `rookie::firefox(...)` fails. If a `cookies.sqlite` database is found under the XDG Firefox config directory, it is passed to `rookie::any_browser(...)`.

This is mainly intended to start discussion around the right approach.

Before merging, I’d like to add tests and decide whether this should parse `profiles.ini` to prefer the default Firefox profile instead of selecting the first profile with `cookies.sqlite`.

If this approach does not make sense for the project, I’m happy to close the PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Firefox data detection by adding a fallback that searches common Firefox profile locations when automatic discovery fails.
  - Firefox-related operations can now recover using a discovered `cookies.sqlite` database.
  - Enhanced error messages provide more context when both discovery methods fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->