### PR TITLE
fix(client): use questionFrontendId for problem metadata & optimize topic attachment

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -171,11 +171,15 @@ impl LeetCodeClient {
 
     /// Fetch a specific problem's details and boilerplate using its URL slug
     pub async fn get_question_by_slug(&self, title_slug: &str) -> Result<Question> {
-        // 1. Define the exact GraphQL query LeetCode expects
+        // 1. Define the exact GraphQL query LeetCode expects.
+        // We request both `questionId` (the internal database ID required by LeetCode's
+        // submission judge endpoints) and `questionFrontendId` (the public problem number
+        // shown to users in the UI and written in problem metadata headers).
         let query_string = r#"
             query questionData($titleSlug: String!) {
                 question(titleSlug: $titleSlug) {
                     questionId
+                    questionFrontendId
                     title
                     titleSlug
                     content

--- a/src/client.rs
+++ b/src/client.rs
@@ -86,7 +86,12 @@ pub trait LeetCodeApi {
 
     fn get_problem_list(
         &self,
-    ) -> impl std::future::Future<Output = Result<Vec<crate::models::ProblemSummary>>> + Send;
+    ) -> impl std::future::Future<
+        Output = Result<(
+            Vec<crate::models::ProblemSummary>,
+            std::collections::HashMap<u64, u64>,
+        )>,
+    > + Send;
 }
 
 /// A configured `reqwest` HTTP client that authenticates every request with
@@ -467,8 +472,14 @@ impl LeetCodeClient {
         Ok(response)
     }
 
-    /// Fetches the master list of all LeetCode problems
-    pub async fn get_problem_list(&self) -> Result<Vec<crate::models::ProblemSummary>> {
+    /// Fetches the master list of all LeetCode problems along with a mapping
+    /// from internal `question_id` to public `frontend_question_id`.
+    pub async fn get_problem_list(
+        &self,
+    ) -> Result<(
+        Vec<crate::models::ProblemSummary>,
+        std::collections::HashMap<u64, u64>,
+    )> {
         let url = "https://leetcode.com/api/problems/all/";
 
         let response = self.http_client.get(url).send().await?;
@@ -487,6 +498,8 @@ impl LeetCodeClient {
             .and_then(|v| v.as_array())
         {
             let mut problems = Vec::with_capacity(pairs.len());
+            let mut id_map = std::collections::HashMap::with_capacity(pairs.len());
+
             for pair in pairs {
                 if let (Some(stat), Some(difficulty), Some(status), Some(paid_only)) = (
                     pair.get("stat"),
@@ -494,10 +507,19 @@ impl LeetCodeClient {
                     pair.get("status"),
                     pair.get("paid_only"),
                 ) {
-                    let id = stat
+                    let internal_id = stat
+                        .get("question_id")
+                        .and_then(|v| v.as_u64())
+                        .unwrap_or(0);
+                    let frontend_id = stat
                         .get("frontend_question_id")
                         .and_then(|v| v.as_u64())
                         .unwrap_or(0);
+
+                    if internal_id > 0 && frontend_id > 0 {
+                        id_map.insert(internal_id, frontend_id);
+                    }
+
                     let title = stat
                         .get("question__title")
                         .and_then(|v| v.as_str())
@@ -521,7 +543,7 @@ impl LeetCodeClient {
                     let acceptance = accepted as f64 / submitted as f64;
 
                     problems.push(crate::models::ProblemSummary {
-                        id,
+                        id: frontend_id,
                         title,
                         slug,
                         difficulty: level,
@@ -536,7 +558,7 @@ impl LeetCodeClient {
             }
             // The API returns them sorted by ID descending by default, let's sort ascending
             problems.sort_by_key(|p| p.id);
-            return Ok(problems);
+            return Ok((problems, id_map));
         }
         Err(EngineError::Other(
             "Error retrieving problem list".to_string(),
@@ -615,7 +637,12 @@ impl LeetCodeApi for LeetCodeClient {
 
     fn get_problem_list(
         &self,
-    ) -> impl std::future::Future<Output = Result<Vec<crate::models::ProblemSummary>>> + Send {
+    ) -> impl std::future::Future<
+        Output = Result<(
+            Vec<crate::models::ProblemSummary>,
+            std::collections::HashMap<u64, u64>,
+        )>,
+    > + Send {
         LeetCodeClient::get_problem_list(self)
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -518,42 +518,47 @@ impl LeetCodeClient {
 
                     if internal_id > 0 && frontend_id > 0 {
                         id_map.insert(internal_id, frontend_id);
+
+                        let title = stat
+                            .get("question__title")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("")
+                            .to_string();
+                        let slug = stat
+                            .get("question__title_slug")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("")
+                            .to_string();
+                        let level = difficulty
+                            .get("level")
+                            .and_then(|v| v.as_u64())
+                            .unwrap_or(0) as u8;
+                        let status = status.as_str().map(String::from);
+                        let accepted = stat.get("total_acs").and_then(|v| v.as_u64()).unwrap_or(0);
+                        let submitted = stat
+                            .get("total_submitted")
+                            .and_then(|v| v.as_u64())
+                            .unwrap_or(0);
+                        // Guard against division by zero for problems with no submissions yet.
+                        let acceptance = if submitted > 0 {
+                            accepted as f64 / submitted as f64
+                        } else {
+                            0.0
+                        };
+
+                        problems.push(crate::models::ProblemSummary {
+                            id: frontend_id,
+                            title,
+                            slug,
+                            difficulty: level,
+                            accepted,
+                            submitted,
+                            acceptance,
+                            status,
+                            is_paid: paid_only.as_bool().unwrap_or(false),
+                            topics: Vec::new(),
+                        });
                     }
-
-                    let title = stat
-                        .get("question__title")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("")
-                        .to_string();
-                    let slug = stat
-                        .get("question__title_slug")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("")
-                        .to_string();
-                    let level = difficulty
-                        .get("level")
-                        .and_then(|v| v.as_u64())
-                        .unwrap_or(0) as u8;
-                    let status = status.as_str().map(String::from);
-                    let accepted = stat.get("total_acs").and_then(|v| v.as_u64()).unwrap_or(0);
-                    let submitted = stat
-                        .get("total_submitted")
-                        .and_then(|v| v.as_u64())
-                        .unwrap_or(0);
-                    let acceptance = accepted as f64 / submitted as f64;
-
-                    problems.push(crate::models::ProblemSummary {
-                        id: frontend_id,
-                        title,
-                        slug,
-                        difficulty: level,
-                        accepted,
-                        submitted,
-                        acceptance,
-                        status,
-                        is_paid: paid_only.as_bool().unwrap_or(false),
-                        topics: Vec::new(),
-                    });
                 }
             }
             // The API returns them sorted by ID descending by default, let's sort ascending

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -139,4 +139,25 @@ mod tests {
         assert_eq!(r.total_correct, Some(0));
         assert_eq!(r.total_testcases, Some(57));
     }
+
+    #[test]
+    fn question_deserializes_both_internal_and_frontend_ids() {
+        let raw = r#"{
+            "questionId": "1677",
+            "questionFrontendId": "1550",
+            "title": "Three Consecutive Odds",
+            "titleSlug": "three-consecutive-odds",
+            "content": "<p>Content</p>",
+            "exampleTestcases": "[1,2,3]",
+            "codeSnippets": [
+                { "langSlug": "rust", "code": "impl Solution {}" }
+            ]
+        }"#;
+        let q: Question = serde_json::from_str(raw).expect("question deserialization failed");
+        assert_eq!(q.question_id, "1677");
+        assert_eq!(q.question_frontend_id, "1550");
+        assert_eq!(q.title_slug, "three-consecutive-odds");
+        assert_eq!(q.title, "Three Consecutive Odds");
+        assert_eq!(q.code_snippets.len(), 1);
+    }
 }

--- a/src/models/problem.rs
+++ b/src/models/problem.rs
@@ -11,7 +11,7 @@ pub struct GraphQLQuery {
 }
 
 /// A single code snippet returned by LeetCode's GraphQL API for one language.
-#[derive(Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct QuestionSnippet {
     #[serde(rename = "langSlug")]
     pub lang_slug: String,
@@ -29,10 +29,26 @@ pub struct UserDetail {
 }
 
 /// Full problem details fetched from the `questionData` GraphQL query.
-#[derive(Deserialize, Debug)]
+///
+/// # Identifier Distinction: `question_id` vs `question_frontend_id`
+///
+/// LeetCode maintains two distinct identifiers for each problem:
+/// - [`question_id`](Self::question_id) (`questionId` in GraphQL / REST):
+///   The internal database primary key. LeetCode's backend judging endpoints
+///   (`/problems/{slug}/submit/` and `/interpret_solution/`) **require** this
+///   internal ID in their JSON submission payloads.
+/// - [`question_frontend_id`](Self::question_frontend_id) (`questionFrontendId` in GraphQL / `frontend_question_id` in REST):
+///   The public-facing problem number visible on leetcode.com, in problem tables,
+///   and in search results (e.g. `1` for Two Sum, `1550` for Three Consecutive Odds).
+///   This ID is used for user display and in generated source file metadata headers.
+#[derive(Deserialize, Debug, Clone)]
 pub struct Question {
+    /// Internal database ID required by LeetCode judging/submission APIs.
     #[serde(rename = "questionId")]
     pub question_id: String,
+    /// Public problem number visible to users on LeetCode and in search.
+    #[serde(rename = "questionFrontendId")]
+    pub question_frontend_id: String,
     #[serde(rename = "titleSlug")]
     pub title_slug: String,
     pub title: String,

--- a/src/picker.rs
+++ b/src/picker.rs
@@ -220,9 +220,9 @@ impl Picker {
                         let user_detail = client_clone.get_user_detail().await?;
                         let data = serde_json::to_string(&user_detail)?;
                         let _ = fs::write(&user_path_bg, data);
-                        let mut problems = client_clone.get_problem_list().await?;
+                        let (mut problems, id_map) = client_clone.get_problem_list().await?;
                         let question_tags = client_clone.get_topics_question_list().await?;
-                        attach_topics(&mut problems, question_tags);
+                        attach_topics(&mut problems, question_tags, &id_map);
                         let data = serde_json::to_string(&problems)?;
                         let _ = fs::write(&data_path_bg, data);
                         Ok(())
@@ -234,9 +234,9 @@ impl Picker {
                 v
             }
             Err(_) => {
-                let mut problems = self.client.get_problem_list().await?;
+                let (mut problems, id_map) = self.client.get_problem_list().await?;
                 let question_tags = self.client.get_topics_question_list().await?;
-                attach_topics(&mut problems, question_tags);
+                attach_topics(&mut problems, question_tags, &id_map);
                 let data = serde_json::to_string(&problems)?;
                 let _ = fs::write(&data_path, &data);
                 data
@@ -256,9 +256,15 @@ impl Picker {
 
 /// Merges topic tag names into each problem's `topics` list in O(P + T * Q) time
 /// using a hash map lookup instead of a nested linear search.
+///
+/// LeetCode's `questionTopicTags` GraphQL response lists problems by their
+/// internal database `questionId`. This function translates each internal ID
+/// to the public `frontend_question_id` (matching `ProblemSummary.id`) before
+/// attaching topics.
 fn attach_topics(
     problems: &mut [ProblemSummary],
     question_tags: Vec<crate::models::QuestionTopics>,
+    internal_to_frontend: &std::collections::HashMap<u64, u64>,
 ) {
     use std::collections::HashMap;
 
@@ -266,8 +272,13 @@ fn attach_topics(
         problems.iter_mut().map(|p| (p.id, p)).collect();
 
     for tag in question_tags {
-        for q_id in tag.question_ids {
-            if let Some(problem) = problem_map.get_mut(&q_id) {
+        for internal_id in tag.question_ids {
+            let frontend_id = internal_to_frontend
+                .get(&internal_id)
+                .copied()
+                .unwrap_or(internal_id);
+
+            if let Some(problem) = problem_map.get_mut(&frontend_id) {
                 problem.topics.push(tag.name.clone());
             }
         }
@@ -278,6 +289,7 @@ fn attach_topics(
 mod tests {
     use super::*;
     use crate::models::{ProblemSummary, QuestionTopics};
+    use std::collections::HashMap;
 
     #[test]
     fn attach_topics_maps_tags_to_matching_problems() {
@@ -332,9 +344,70 @@ mod tests {
             },
         ];
 
-        attach_topics(&mut problems, tags);
+        let id_map = HashMap::new();
+        attach_topics(&mut problems, tags, &id_map);
 
         assert_eq!(problems[0].topics, vec!["Array", "Hash Table"]);
         assert_eq!(problems[1].topics, vec!["Math"]);
+    }
+
+    #[test]
+    fn attach_topics_translates_unequal_internal_and_frontend_ids() {
+        let mut problems = vec![
+            ProblemSummary {
+                id: 1550, // Public Frontend ID
+                acceptance: 50.0,
+                accepted: 100,
+                difficulty: 1,
+                slug: "three-consecutive-odds".to_string(),
+                status: None,
+                submitted: 200,
+                title: "Three Consecutive Odds".to_string(),
+                is_paid: false,
+                topics: vec![],
+            },
+            ProblemSummary {
+                id: 1677, // Another problem whose frontend ID equals 1677
+                acceptance: 40.0,
+                accepted: 80,
+                difficulty: 2,
+                slug: "products-worth-over-invoice".to_string(),
+                status: None,
+                submitted: 200,
+                title: "Products' Worth Over Invoices".to_string(),
+                is_paid: false,
+                topics: vec![],
+            },
+        ];
+
+        // Mapping: internal ID 1677 translates to public frontend ID 1550,
+        // while internal ID 1800 translates to public frontend ID 1677.
+        let mut id_map = HashMap::new();
+        id_map.insert(1677, 1550);
+        id_map.insert(1800, 1677);
+
+        // Tags from GraphQL with internal question IDs
+        let tags = vec![
+            QuestionTopics {
+                name: "Array".to_string(),
+                id: "array".to_string(),
+                slug: "array".to_string(),
+                translated_name: None,
+                question_ids: vec![1677],
+            },
+            QuestionTopics {
+                name: "Database".to_string(),
+                id: "database".to_string(),
+                slug: "database".to_string(),
+                translated_name: None,
+                question_ids: vec![1800],
+            },
+        ];
+
+        attach_topics(&mut problems, tags, &id_map);
+
+        // Verify topic "Array" was attached to problem #1550 (not problem #1677)
+        assert_eq!(problems[0].topics, vec!["Array"]);
+        assert_eq!(problems[1].topics, vec!["Database"]);
     }
 }

--- a/src/picker.rs
+++ b/src/picker.rs
@@ -210,15 +210,7 @@ impl Picker {
                         let _ = fs::write(&user_path_bg, data);
                         let mut problems = client_clone.get_problem_list().await?;
                         let question_tags = client_clone.get_topics_question_list().await?;
-                        for question_tag in question_tags {
-                            question_tag.question_ids.iter().for_each(|question_id| {
-                                if let Some(problem) =
-                                    problems.iter_mut().find(|p| p.id == *question_id)
-                                {
-                                    problem.topics.push(question_tag.name.clone());
-                                }
-                            });
-                        }
+                        attach_topics(&mut problems, question_tags);
                         let data = serde_json::to_string(&problems)?;
                         let _ = fs::write(&data_path_bg, data);
                         Ok(())
@@ -232,13 +224,7 @@ impl Picker {
             Err(_) => {
                 let mut problems = self.client.get_problem_list().await?;
                 let question_tags = self.client.get_topics_question_list().await?;
-                for question_tag in question_tags {
-                    question_tag.question_ids.iter().for_each(|question_id| {
-                        if let Some(problem) = problems.iter_mut().find(|p| p.id == *question_id) {
-                            problem.topics.push(question_tag.name.clone());
-                        }
-                    });
-                }
+                attach_topics(&mut problems, question_tags);
                 let data = serde_json::to_string(&problems)?;
                 let _ = fs::write(&data_path, &data);
                 data
@@ -253,5 +239,90 @@ impl Picker {
             e
         })?;
         Ok(problems)
+    }
+}
+
+/// Merges topic tag names into each problem's `topics` list in O(P + T * Q) time
+/// using a hash map lookup instead of a nested linear search.
+fn attach_topics(
+    problems: &mut [ProblemSummary],
+    question_tags: Vec<crate::models::QuestionTopics>,
+) {
+    use std::collections::HashMap;
+
+    let mut problem_map: HashMap<u64, &mut ProblemSummary> =
+        problems.iter_mut().map(|p| (p.id, p)).collect();
+
+    for tag in question_tags {
+        for q_id in tag.question_ids {
+            if let Some(problem) = problem_map.get_mut(&q_id) {
+                problem.topics.push(tag.name.clone());
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::{ProblemSummary, QuestionTopics};
+
+    #[test]
+    fn attach_topics_maps_tags_to_matching_problems() {
+        let mut problems = vec![
+            ProblemSummary {
+                id: 1,
+                acceptance: 50.0,
+                accepted: 100,
+                difficulty: 1,
+                slug: "two-sum".to_string(),
+                status: None,
+                submitted: 200,
+                title: "Two Sum".to_string(),
+                is_paid: false,
+                topics: vec![],
+            },
+            ProblemSummary {
+                id: 2,
+                acceptance: 40.0,
+                accepted: 80,
+                difficulty: 2,
+                slug: "add-two-numbers".to_string(),
+                status: None,
+                submitted: 200,
+                title: "Add Two Numbers".to_string(),
+                is_paid: false,
+                topics: vec![],
+            },
+        ];
+
+        let tags = vec![
+            QuestionTopics {
+                name: "Array".to_string(),
+                id: "array".to_string(),
+                slug: "array".to_string(),
+                translated_name: None,
+                question_ids: vec![1],
+            },
+            QuestionTopics {
+                name: "Math".to_string(),
+                id: "math".to_string(),
+                slug: "math".to_string(),
+                translated_name: None,
+                question_ids: vec![2],
+            },
+            QuestionTopics {
+                name: "Hash Table".to_string(),
+                id: "hash-table".to_string(),
+                slug: "hash-table".to_string(),
+                translated_name: None,
+                question_ids: vec![1],
+            },
+        ];
+
+        attach_topics(&mut problems, tags);
+
+        assert_eq!(problems[0].topics, vec!["Array", "Hash Table"]);
+        assert_eq!(problems[1].topics, vec!["Math"]);
     }
 }

--- a/src/picker.rs
+++ b/src/picker.rs
@@ -30,8 +30,15 @@ impl Picker {
     /// Resolves a problem by [`Identifier`], writes the Markdown description
     /// and language-specific code stub to disk, and returns their paths.
     ///
-    /// If both files already exist on disk (slug-based match) they are returned
-    /// immediately without hitting the network.
+    /// # Existing Files & Migration Policy
+    /// If both code and description files already exist on disk (slug-based match),
+    /// they are returned immediately without network access. Existing files are
+    /// intentionally left unmodified to safeguard user code. Legacy files containing
+    /// the older internal `question_id` in their comment headers remain fully
+    /// compatible because submission and testing resolve the problem metadata
+    /// dynamically via the filename slug, not from the comment header.
+    ///
+    /// Newly generated files will have `question_frontend_id` in their headers.
     ///
     /// # Returns
     /// `(code_file_path, description_file_path)` on success.
@@ -55,6 +62,8 @@ impl Picker {
 
         //TODO: If language is specified, must open that file
         // else open the file with matching slug.
+        // Early-return if files already exist: we preserve existing user code as-is
+        // without rewriting comment headers.
         if let Identifier::String(ident) = identifier {
             let snake_slug = ident.replace("-", "_");
             let code_filename = format!("{}.{}", snake_slug, language.code_extension());

--- a/src/picker.rs
+++ b/src/picker.rs
@@ -100,10 +100,13 @@ impl Picker {
         let code_filename = format!("{}.{}", snake_slug, language.code_extension());
         let desc_filename = format!("{}.md", snake_slug);
 
+        // Write metadata comment at the top of the generated code file.
+        // We use `question_frontend_id` (the public problem number on LeetCode) so the file
+        // header displays the familiar number matching the website and CLI search.
         let meta = format!(
             "{} id={} slug={} lang={}",
             language.meta_comment_prefix(),
-            question.question_id,
+            question.question_frontend_id,
             question.title_slug,
             language.to_lang_slug()
         );

--- a/src/picker.rs
+++ b/src/picker.rs
@@ -266,17 +266,18 @@ fn attach_topics(
     question_tags: Vec<crate::models::QuestionTopics>,
     internal_to_frontend: &std::collections::HashMap<u64, u64>,
 ) {
-    use std::collections::HashMap;
-
-    let mut problem_map: HashMap<u64, &mut ProblemSummary> =
+    let mut problem_map: std::collections::HashMap<u64, &mut ProblemSummary> =
         problems.iter_mut().map(|p| (p.id, p)).collect();
 
     for tag in question_tags {
         for internal_id in tag.question_ids {
-            let frontend_id = internal_to_frontend
-                .get(&internal_id)
-                .copied()
-                .unwrap_or(internal_id);
+            // Problems where internal_id == frontend_id will always be found in
+            // the map (the REST endpoint lists all problems). If a mapping is
+            // missing we skip rather than guessing, to avoid attaching the wrong
+            // topic to an unrelated problem.
+            let Some(&frontend_id) = internal_to_frontend.get(&internal_id) else {
+                continue;
+            };
 
             if let Some(problem) = problem_map.get_mut(&frontend_id) {
                 problem.topics.push(tag.name.clone());
@@ -344,7 +345,10 @@ mod tests {
             },
         ];
 
-        let id_map = HashMap::new();
+        // These problems have equal internal and frontend IDs — the common case
+        // for older problems. The map must still be populated; we no longer fall
+        // back to the raw internal ID when a mapping is absent.
+        let id_map = HashMap::from([(1u64, 1u64), (2u64, 2u64)]);
         attach_topics(&mut problems, tags, &id_map);
 
         assert_eq!(problems[0].topics, vec!["Array", "Hash Table"]);

--- a/src/services/submission.rs
+++ b/src/services/submission.rs
@@ -120,6 +120,8 @@ impl SubmissionService {
         println!("🚀 Submitting {}...", file);
 
         if is_test {
+            // NOTE: LeetCode's interpret_solution endpoint requires the internal `question_id`
+            // (not the public `question_frontend_id`) in its request payload.
             let interpret_id = self
                 .client
                 .test_code(
@@ -161,6 +163,8 @@ impl SubmissionService {
                 code_output: r.code_output.map(|v| v.join("\t")),
             })
         } else {
+            // NOTE: LeetCode's submit endpoint requires the internal `question_id`
+            // (not the public `question_frontend_id`) in its request payload.
             let submission_id = self
                 .client
                 .submit_code(&slug, &question.question_id, language.to_lang_slug(), &code)

--- a/src/tui/widgets/filter_state.rs
+++ b/src/tui/widgets/filter_state.rs
@@ -18,6 +18,16 @@ use crate::models::ProblemSummary;
 // just to build the list of filterable topics.
 const TOPICS_TXT: &str = include_str!("../../../topics.txt");
 
+static STATIC_TOPICS: std::sync::LazyLock<Vec<String>> = std::sync::LazyLock::new(|| {
+    let mut topics: Vec<String> = TOPICS_TXT
+        .lines()
+        .map(|line| line.trim().trim_matches('"').to_string())
+        .filter(|s| !s.is_empty())
+        .collect();
+    topics.sort();
+    topics
+});
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum TopicInputMode {
     #[default]
@@ -40,13 +50,7 @@ impl TopicFilterState {
     /// Constructs a new [`TopicFilterState`] populated with topics loaded
     /// directly from `topics.txt`.
     pub fn new() -> Self {
-        // Parse raw topic lines, trimming surrounding quotes and whitespace.
-        let mut all_topics: Vec<String> = TOPICS_TXT
-            .lines()
-            .map(|line| line.trim().trim_matches('"').to_string())
-            .filter(|s| !s.is_empty())
-            .collect();
-        all_topics.sort();
+        let all_topics = STATIC_TOPICS.clone();
 
         let mut list_state = ListState::default();
         if !all_topics.is_empty() {


### PR DESCRIPTION
 ## 🎯 Fix problem ID mismatch & optimize topic tag attachment
 
 Fixes: #14 

  ### Summary

  Resolves a problem ID discrepancy between LeetCode's internal database ID (questionId) and the public-facing problem number
  (questionFrontendId), ensuring generated file headers display the correct problem number while preserving submission judge
  compatibility. Also optimizes topic tag merging from O(T × Q × P) to O(P + T × Q).
  ──────
  ### Key Changes

  • GraphQL & Models (src/client.rs, src/models/problem.rs):
      • Added questionFrontendId to the questionData GraphQL query.
      • Added question_frontend_id to problem.rs:44-55 with documentation detailing the distinction between internal DB ID and
      public frontend ID.
  • File Metadata (src/picker.rs):
      • Updated code file header generation to use question_frontend_id (e.g. // id=1550 ... instead of internal // id=1677 ...
      ).
  • Submission Safety (src/services/submission.rs):
      • Documented that /submit/ and /interpret_solution/ payloads strictly require the internal question_id.
  • Performance Optimizations (src/picker.rs, src/tui/widgets/filter_state.rs):
      • Replaced O(T × Q × P) linear scanning with a O(P + T × Q) HashMap lookup in attach_topics.
      • Cached static topic catalog parsing using std::sync::LazyLock.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

- **Bug Fixes**
  - Generated solution metadata now uses the public problem number.
  - Problem topics are assigned more reliably when listing and filtering problems.
  - Problem data now preserves both public and internal identifiers for accurate submissions.

- **Performance**
  - Topic information loads more efficiently by avoiding repeated parsing.

- **Documentation**
  - Added clearer explanations of public problem numbers and internal identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->